### PR TITLE
Add resource bundle installer plugin

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,0 +1,12 @@
+/**
+ * Composer installer plugin for Fast Forward resource bundles.
+ *
+ * This file is part of fast-forward/composer-installers project.
+ *
+ * @author   Felipe Sayao Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/composer-installers
+ * @see      https://github.com/php-fast-forward/composer-installers/issues
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*              text=auto
+/tests/        export-ignore
+/.gitattributes export-ignore
+/.gitignore   export-ignore
+/AGENTS.md    export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.phpunit.result.cache
+/backup/
+/tmp/
+/vendor/
+composer.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Project Overview
+
+`fast-forward/composer-installers` is a Composer plugin that materializes Fast
+Forward resource-bundle payloads into consumer repositories.
+
+The package intentionally starts small: it installs package roots through
+Composer's normal vendor flow, then copies only declared payload contents into
+consumer-owned target directories.
+
+## Setup Commands
+
+Install dependencies with:
+
+```bash
+composer install
+```
+
+## Development Workflow
+
+Important paths:
+
+- `src/Plugin.php` registers the Composer installer.
+- `src/ResourceBundleInstaller.php` hooks Composer package install, update, and uninstall operations.
+- `src/ResourceBundleMaterializer.php` copies payload files and maintains the installer manifest.
+- `README.md` documents the bundle metadata and consumer configuration contract.
+
+Do not add GitHub workflows in this repository yet; shared workflows are being
+externalized separately.
+
+## Testing Instructions
+
+Use the smallest relevant check while editing:
+
+```bash
+composer validate --strict
+```
+
+For installer behavior, create a throwaway consumer project that requires this
+repository and a local `fast-forward-resource-bundle` package through Composer
+`path` repositories.
+
+## Code Style
+
+Keep PHP code strict, focused, and side-effect conscious. Do not silently
+overwrite consumer-owned files; only refresh files tracked by the installer
+manifest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Bootstrap the `fast-forward/composer-installers` Composer plugin for Fast Forward resource bundles.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fast Forward
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,60 @@
 
 Composer installer plugin for Fast Forward resource bundle packages.
 
-This repository is being prepared so Fast Forward packages can install only
-their resource payloads into consumer-owned directories.
+`fast-forward/composer-installers` lets Fast Forward packages declare a payload
+directory and lets consumer roots choose where that payload is copied. The
+package root still lives in `vendor/`, but only the declared payload contents
+are materialized into consumer-owned paths.
+
+## Resource Package Metadata
+
+Resource packages use the `fast-forward-resource-bundle` type and declare the
+payload directory to copy:
+
+```json
+{
+  "type": "fast-forward-resource-bundle",
+  "extra": {
+    "fast-forward-bundle": {
+      "payload-path": ".agents"
+    }
+  }
+}
+```
+
+## Consumer Configuration
+
+Consumer repositories allow this Composer plugin and map resource packages to
+target directories:
+
+```json
+{
+  "config": {
+    "allow-plugins": {
+      "fast-forward/composer-installers": true
+    }
+  },
+  "extra": {
+    "installer-paths": {
+      ".agents/": ["fast-forward/agents"],
+      ".github/workflows/": ["fast-forward/github-workflows"]
+    }
+  }
+}
+```
+
+The target path receives the payload contents. For `fast-forward/agents`, that
+means `.agents/agents` and `.agents/skills` are copied into the consumer project
+without creating `.agents/agents/.agents`.
+
+## Update Behavior
+
+The installer writes a manifest under `vendor/fast-forward/.composer-installers`
+for each materialized package. On package update, files listed in the manifest
+are refreshed from the new payload and stale managed files are removed. Files
+that already exist in the target but are not tracked by the manifest are treated
+as consumer-owned and are not silently overwritten.
+
+The materialized payload is copied as literal files and directories. Composer
+`path` repositories may still symlink the package root in `vendor/`, but the
+consumer-facing payload remains copied.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,55 @@
+{
+    "name": "fast-forward/composer-installers",
+    "description": "Composer installer plugin for Fast Forward resource bundles.",
+    "license": "MIT",
+    "type": "composer-plugin",
+    "keywords": [
+        "composer",
+        "fast-forward",
+        "installer",
+        "plugin",
+        "resources"
+    ],
+    "readme": "README.md",
+    "authors": [
+        {
+            "name": "Felipe Sayao Lobato Abreu",
+            "email": "github@mentordosnerds.com",
+            "homepage": "https://github.com/coisa",
+            "role": "Maintainer"
+        }
+    ],
+    "homepage": "https://github.com/php-fast-forward/composer-installers",
+    "support": {
+        "issues": "https://github.com/php-fast-forward/composer-installers/issues",
+        "source": "https://github.com/php-fast-forward/composer-installers"
+    },
+    "require": {
+        "php": "^8.3",
+        "composer-plugin-api": "^2.6"
+    },
+    "require-dev": {
+        "composer/composer": "^2.8"
+    },
+    "minimum-stability": "stable",
+    "autoload": {
+        "psr-4": {
+            "FastForward\\ComposerInstallers\\": "src/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "fast-forward/composer-installers": true
+        },
+        "platform": {
+            "php": "8.3.0"
+        },
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.x-dev"
+        },
+        "class": "FastForward\\ComposerInstallers\\Plugin"
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FastForward\ComposerInstallers;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+
+final class Plugin implements PluginInterface
+{
+    private ?ResourceBundleInstaller $installer = null;
+
+    public function activate(Composer $composer, IOInterface $io): void
+    {
+        $this->installer = new ResourceBundleInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($this->installer);
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io): void
+    {
+        if (null !== $this->installer) {
+            $composer->getInstallationManager()->removeInstaller($this->installer);
+            $this->installer = null;
+        }
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io): void
+    {
+        $this->deactivate($composer, $io);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,22 +2,54 @@
 
 declare(strict_types=1);
 
+/**
+ * Composer installer plugin for Fast Forward resource bundles.
+ *
+ * This file is part of fast-forward/composer-installers project.
+ *
+ * @author   Felipe Sayao Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/composer-installers
+ * @see      https://github.com/php-fast-forward/composer-installers/issues
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
 namespace FastForward\ComposerInstallers;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 
+/**
+ * Registers the Fast Forward resource bundle installer with Composer.
+ *
+ * This plugin keeps the installer lifecycle aligned with Composer plugin
+ * activation, deactivation, and uninstall hooks.
+ */
 final class Plugin implements PluginInterface
 {
+    /**
+     * The installer registered during the active Composer plugin lifecycle.
+     */
     private ?ResourceBundleInstaller $installer = null;
 
+    /**
+     * Activates the Composer plugin and registers the resource bundle installer.
+     *
+     * @return void
+     */
     public function activate(Composer $composer, IOInterface $io): void
     {
         $this->installer = new ResourceBundleInstaller($io, $composer);
         $composer->getInstallationManager()->addInstaller($this->installer);
     }
 
+    /**
+     * Deactivates the Composer plugin and removes the registered installer.
+     *
+     * @return void
+     */
     public function deactivate(Composer $composer, IOInterface $io): void
     {
         if (null !== $this->installer) {
@@ -26,6 +58,11 @@ final class Plugin implements PluginInterface
         }
     }
 
+    /**
+     * Uninstalls the Composer plugin by delegating to the deactivation routine.
+     *
+     * @return void
+     */
     public function uninstall(Composer $composer, IOInterface $io): void
     {
         $this->deactivate($composer, $io);

--- a/src/ResourceBundleInstaller.php
+++ b/src/ResourceBundleInstaller.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FastForward\ComposerInstallers;
+
+use Composer\Composer;
+use Composer\Installer\LibraryInstaller;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
+use React\Promise\PromiseInterface;
+
+final class ResourceBundleInstaller extends LibraryInstaller
+{
+    public const string PACKAGE_TYPE = 'fast-forward-resource-bundle';
+
+    private ResourceBundleMaterializer $materializer;
+
+    public function __construct(IOInterface $io, Composer $composer)
+    {
+        parent::__construct($io, $composer, self::PACKAGE_TYPE);
+
+        $this->materializer = new ResourceBundleMaterializer($composer, $io);
+    }
+
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        $promise = parent::install($repo, $package);
+
+        return $this->after($promise, function () use ($package): void {
+            $this->materializer->materialize($package, $this->getInstallPath($package));
+        });
+    }
+
+    public function update(
+        InstalledRepositoryInterface $repo,
+        PackageInterface $initial,
+        PackageInterface $target,
+    ) {
+        $promise = parent::update($repo, $initial, $target);
+
+        return $this->after($promise, function () use ($target): void {
+            $this->materializer->materialize($target, $this->getInstallPath($target));
+        });
+    }
+
+    public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        $this->materializer->remove($package);
+
+        return parent::uninstall($repo, $package);
+    }
+
+    /**
+     * @param callable(): void $callback
+     */
+    private function after(?PromiseInterface $promise, callable $callback): ?PromiseInterface
+    {
+        if ($promise instanceof PromiseInterface) {
+            return $promise->then(static function () use ($callback): void {
+                $callback();
+            });
+        }
+
+        $callback();
+
+        return null;
+    }
+}

--- a/src/ResourceBundleInstaller.php
+++ b/src/ResourceBundleInstaller.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/**
+ * Composer installer plugin for Fast Forward resource bundles.
+ *
+ * This file is part of fast-forward/composer-installers project.
+ *
+ * @author   Felipe Sayao Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/composer-installers
+ * @see      https://github.com/php-fast-forward/composer-installers/issues
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
 namespace FastForward\ComposerInstallers;
 
 use Composer\Composer;
@@ -11,12 +24,27 @@ use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use React\Promise\PromiseInterface;
 
+/**
+ * Installs Composer packages that expose Fast Forward resource payloads.
+ *
+ * The package root remains under Composer's vendor directory while the declared
+ * payload is materialized into the consumer path selected by the root package.
+ */
 final class ResourceBundleInstaller extends LibraryInstaller
 {
+    /**
+     * Composer package type handled by this installer.
+     */
     public const string PACKAGE_TYPE = 'fast-forward-resource-bundle';
 
+    /**
+     * Copies and tracks resource payloads after Composer installs package code.
+     */
     private ResourceBundleMaterializer $materializer;
 
+    /**
+     * Creates the installer for Fast Forward resource bundle packages.
+     */
     public function __construct(IOInterface $io, Composer $composer)
     {
         parent::__construct($io, $composer, self::PACKAGE_TYPE);
@@ -24,6 +52,11 @@ final class ResourceBundleInstaller extends LibraryInstaller
         $this->materializer = new ResourceBundleMaterializer($composer, $io);
     }
 
+    /**
+     * Installs the package and materializes its resource payload.
+     *
+     * @return PromiseInterface|null
+     */
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         $promise = parent::install($repo, $package);
@@ -33,6 +66,11 @@ final class ResourceBundleInstaller extends LibraryInstaller
         });
     }
 
+    /**
+     * Updates the package and refreshes the materialized resource payload.
+     *
+     * @return PromiseInterface|null
+     */
     public function update(
         InstalledRepositoryInterface $repo,
         PackageInterface $initial,
@@ -45,6 +83,11 @@ final class ResourceBundleInstaller extends LibraryInstaller
         });
     }
 
+    /**
+     * Removes the materialized payload and delegates package removal to Composer.
+     *
+     * @return PromiseInterface|null
+     */
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         $this->materializer->remove($package);
@@ -53,7 +96,12 @@ final class ResourceBundleInstaller extends LibraryInstaller
     }
 
     /**
+     * Runs a callback after a Composer promise resolves, or immediately when no
+     * promise exists.
+     *
      * @param callable(): void $callback
+     *
+     * @return PromiseInterface|null
      */
     private function after(?PromiseInterface $promise, callable $callback): ?PromiseInterface
     {

--- a/src/ResourceBundleMaterializer.php
+++ b/src/ResourceBundleMaterializer.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FastForward\ComposerInstallers;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
+use Composer\Util\Filesystem;
+use RuntimeException;
+
+final class ResourceBundleMaterializer
+{
+    private const string BUNDLE_EXTRA_KEY = 'fast-forward-bundle';
+
+    private const string INSTALLER_PATHS_KEY = 'installer-paths';
+
+    private const string PAYLOAD_PATH_KEY = 'payload-path';
+
+    private readonly Filesystem $filesystem;
+
+    private readonly string $vendorDir;
+
+    private readonly string $manifestDir;
+
+    private readonly string $rootDir;
+
+    public function __construct(
+        private readonly Composer $composer,
+        private readonly IOInterface $io,
+    ) {
+        $this->filesystem = new Filesystem();
+        $vendorDir = rtrim((string) $composer->getConfig()->get('vendor-dir', Config::RELATIVE_PATHS), '/');
+        $configSource = $composer->getConfig()->getConfigSource()->getName();
+        $rootDir = \is_string($configSource) && is_file($configSource)
+            ? \dirname($configSource)
+            : (getcwd() ?: '.');
+
+        if (str_starts_with($vendorDir, '/')) {
+            $this->vendorDir = $vendorDir;
+            $this->rootDir = $rootDir;
+            $this->manifestDir = $this->join($this->rootDir, 'vendor/fast-forward/.composer-installers');
+
+            return;
+        }
+
+        $this->rootDir = $rootDir;
+        $this->vendorDir = $this->join($this->rootDir, $vendorDir);
+        $this->manifestDir = $this->join($this->rootDir, 'vendor/fast-forward/.composer-installers');
+    }
+
+    public function materialize(PackageInterface $package, string $installPath): void
+    {
+        $payloadPath = $this->payloadPath($package);
+        $source = $this->join($installPath, $payloadPath);
+        $target = $this->targetPath($package);
+
+        if (! is_dir($source)) {
+            throw new RuntimeException(\sprintf(
+                'Fast Forward resource bundle "%s" payload path "%s" does not exist.',
+                $package->getPrettyName(),
+                $payloadPath,
+            ));
+        }
+
+        $previousManifest = $this->readManifest($package);
+        $nextEntries = $this->scanPayload($source);
+
+        $this->removeStaleEntries($previousManifest['entries'] ?? [], $nextEntries, $target);
+        $this->copyEntries($source, $target, $nextEntries, $previousManifest['entries'] ?? []);
+        $this->writeManifest($package, [
+            'package' => $package->getPrettyName(),
+            'payload-path' => $payloadPath,
+            'target-path' => $this->relativePath($target),
+            'entries' => $nextEntries,
+        ]);
+
+        $this->io->writeError(\sprintf(
+            '<info>Materialized %s resource payload into %s.</info>',
+            $package->getPrettyName(),
+            $this->relativePath($target),
+        ), true, IOInterface::VERBOSE);
+    }
+
+    public function remove(PackageInterface $package): void
+    {
+        $manifest = $this->readManifest($package);
+        $targetPath = $manifest['target-path'] ?? null;
+        $entries = $manifest['entries'] ?? [];
+
+        if (! \is_string($targetPath) || ! \is_array($entries)) {
+            return;
+        }
+
+        $target = $this->absolutePath($targetPath);
+        $this->removeEntries($entries, $target);
+
+        $manifestPath = $this->manifestPath($package);
+        if (is_file($manifestPath)) {
+            unlink($manifestPath);
+        }
+    }
+
+    /**
+     * @return array<string, array{type: string, hash?: string}>
+     */
+    private function scanPayload(string $source): array
+    {
+        $entries = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            $path = $item->getPathname();
+            $relativePath = $this->normalizePath(substr($path, \strlen($source) + 1));
+
+            if ($item->isDir()) {
+                $entries[$relativePath] = ['type' => 'dir'];
+
+                continue;
+            }
+
+            if ($item->isFile()) {
+                $entries[$relativePath] = [
+                    'type' => 'file',
+                    'hash' => hash_file('sha256', $path) ?: '',
+                ];
+            }
+        }
+
+        ksort($entries);
+
+        return $entries;
+    }
+
+    /**
+     * @param array<string, array{type: string, hash?: string}> $entries
+     * @param array<string, array{type: string, hash?: string}> $previousEntries
+     */
+    private function copyEntries(string $source, string $target, array $entries, array $previousEntries): void
+    {
+        foreach ($entries as $relativePath => $entry) {
+            $sourcePath = $this->join($source, $relativePath);
+            $targetPath = $this->join($target, $relativePath);
+
+            if ('dir' === $entry['type']) {
+                if (is_file($targetPath) || is_link($targetPath)) {
+                    throw $this->conflict($targetPath);
+                }
+
+                if (! is_dir($targetPath)) {
+                    mkdir($targetPath, 0777, true);
+                }
+
+                continue;
+            }
+
+            if (file_exists($targetPath) && ! isset($previousEntries[$relativePath])) {
+                throw $this->conflict($targetPath);
+            }
+
+            $parent = \dirname($targetPath);
+            if (! is_dir($parent)) {
+                mkdir($parent, 0777, true);
+            }
+
+            if (! copy($sourcePath, $targetPath)) {
+                throw new RuntimeException(\sprintf('Failed to copy "%s" to "%s".', $sourcePath, $targetPath));
+            }
+        }
+    }
+
+    /**
+     * @param array<string, array{type: string, hash?: string}> $previousEntries
+     * @param array<string, array{type: string, hash?: string}> $nextEntries
+     */
+    private function removeStaleEntries(array $previousEntries, array $nextEntries, string $target): void
+    {
+        $staleEntries = array_diff_key($previousEntries, $nextEntries);
+        $this->removeEntries($staleEntries, $target);
+    }
+
+    /**
+     * @param array<string, array{type: string, hash?: string}> $entries
+     */
+    private function removeEntries(array $entries, string $target): void
+    {
+        uksort($entries, static fn(string $left, string $right): int => substr_count($right, '/') <=> substr_count($left, '/'));
+
+        foreach ($entries as $relativePath => $entry) {
+            $targetPath = $this->join($target, $relativePath);
+
+            if ('file' === $entry['type'] && is_file($targetPath)) {
+                unlink($targetPath);
+
+                continue;
+            }
+
+            if ('dir' === $entry['type'] && is_dir($targetPath) && $this->filesystem->isDirEmpty($targetPath)) {
+                rmdir($targetPath);
+            }
+        }
+    }
+
+    private function targetPath(PackageInterface $package): string
+    {
+        $rootExtra = $this->composer->getPackage()->getExtra();
+        $installerPaths = $rootExtra[self::INSTALLER_PATHS_KEY] ?? [];
+
+        if (! \is_array($installerPaths)) {
+            throw new RuntimeException('Root extra.installer-paths must be an object mapping paths to package matches.');
+        }
+
+        foreach ($installerPaths as $path => $matches) {
+            if (! \is_array($matches)) {
+                continue;
+            }
+
+            foreach ($matches as $match) {
+                if ($this->matchesPackage((string) $match, $package)) {
+                    return $this->absolutePath($this->replaceVariables((string) $path, $package));
+                }
+            }
+        }
+
+        throw new RuntimeException(\sprintf(
+            'No root extra.installer-paths entry matches Fast Forward resource bundle "%s".',
+            $package->getPrettyName(),
+        ));
+    }
+
+    private function matchesPackage(string $match, PackageInterface $package): bool
+    {
+        return $match === $package->getName()
+            || $match === $package->getPrettyName()
+            || $match === 'type:' . ResourceBundleInstaller::PACKAGE_TYPE;
+    }
+
+    private function payloadPath(PackageInterface $package): string
+    {
+        $extra = $package->getExtra();
+        $metadata = $extra[self::BUNDLE_EXTRA_KEY] ?? [];
+
+        if (! \is_array($metadata) || ! isset($metadata[self::PAYLOAD_PATH_KEY])) {
+            throw new RuntimeException(\sprintf(
+                'Fast Forward resource bundle "%s" must declare extra.%s.%s.',
+                $package->getPrettyName(),
+                self::BUNDLE_EXTRA_KEY,
+                self::PAYLOAD_PATH_KEY,
+            ));
+        }
+
+        $payloadPath = $this->normalizePath((string) $metadata[self::PAYLOAD_PATH_KEY]);
+        if ('' === $payloadPath || str_starts_with($payloadPath, '/') || str_contains($payloadPath, '..')) {
+            throw new RuntimeException(\sprintf(
+                'Fast Forward resource bundle "%s" declares an invalid payload path "%s".',
+                $package->getPrettyName(),
+                $payloadPath,
+            ));
+        }
+
+        return $payloadPath;
+    }
+
+    /**
+     * @return array{entries?: array<string, array{type: string, hash?: string}>, target-path?: string}
+     */
+    private function readManifest(PackageInterface $package): array
+    {
+        $manifestPath = $this->manifestPath($package);
+        if (! is_file($manifestPath)) {
+            return [];
+        }
+
+        $contents = file_get_contents($manifestPath);
+        if (! \is_string($contents)) {
+            return [];
+        }
+
+        $manifest = json_decode($contents, true, 512, \JSON_THROW_ON_ERROR);
+
+        return \is_array($manifest) ? $manifest : [];
+    }
+
+    /**
+     * @param array<string, mixed> $manifest
+     */
+    private function writeManifest(PackageInterface $package, array $manifest): void
+    {
+        $manifestPath = $this->manifestPath($package);
+        $manifestDirectory = \dirname($manifestPath);
+
+        if (! is_dir($manifestDirectory)) {
+            mkdir($manifestDirectory, 0777, true);
+        }
+
+        file_put_contents(
+            $manifestPath,
+            json_encode($manifest, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR) . "\n",
+        );
+    }
+
+    private function manifestPath(PackageInterface $package): string
+    {
+        return $this->join(
+            $this->manifestDir,
+            str_replace('/', '_', $package->getName()) . '.json',
+        );
+    }
+
+    private function replaceVariables(string $path, PackageInterface $package): string
+    {
+        [$vendor, $name] = explode('/', $package->getPrettyName(), 2) + ['', $package->getPrettyName()];
+
+        return strtr($path, [
+            '{$name}' => $name,
+            '{$vendor}' => $vendor,
+            '{$vendor-dir}' => $this->vendorDir,
+        ]);
+    }
+
+    private function absolutePath(string $path): string
+    {
+        if (str_starts_with($path, '/')) {
+            return rtrim($path, '/');
+        }
+
+        return rtrim($this->rootDir . '/' . $path, '/');
+    }
+
+    private function relativePath(string $path): string
+    {
+        $path = $this->normalizePath($path);
+        $root = $this->normalizePath($this->rootDir) . '/';
+
+        if (str_starts_with($path, $root)) {
+            return substr($path, \strlen($root));
+        }
+
+        return $path;
+    }
+
+    private function join(string $left, string $right): string
+    {
+        return rtrim($left, '/') . '/' . ltrim($right, '/');
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return str_replace('\\', '/', trim($path, '/'));
+    }
+
+    private function conflict(string $path): RuntimeException
+    {
+        return new RuntimeException(\sprintf(
+            'Refusing to overwrite consumer-owned path "%s". Remove it or let the installer manage it first.',
+            $this->relativePath($path),
+        ));
+    }
+}

--- a/src/ResourceBundleMaterializer.php
+++ b/src/ResourceBundleMaterializer.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/**
+ * Composer installer plugin for Fast Forward resource bundles.
+ *
+ * This file is part of fast-forward/composer-installers project.
+ *
+ * @author   Felipe Sayao Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/composer-installers
+ * @see      https://github.com/php-fast-forward/composer-installers/issues
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
 namespace FastForward\ComposerInstallers;
 
 use Composer\Composer;
@@ -9,24 +22,56 @@ use Composer\Config;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Util\Filesystem;
+use JsonException;
 use RuntimeException;
 
+/**
+ * Copies resource bundle payloads into consumer-selected target directories.
+ *
+ * Materialized files are tracked in a manifest so package updates can refresh
+ * managed files and remove stale managed paths without deleting local consumer
+ * files.
+ */
 final class ResourceBundleMaterializer
 {
+    /**
+     * Resource package metadata key used to configure bundle behavior.
+     */
     private const string BUNDLE_EXTRA_KEY = 'fast-forward-bundle';
 
+    /**
+     * Root package metadata key used to map packages to target paths.
+     */
     private const string INSTALLER_PATHS_KEY = 'installer-paths';
 
+    /**
+     * Resource package metadata key containing the payload directory.
+     */
     private const string PAYLOAD_PATH_KEY = 'payload-path';
 
+    /**
+     * Filesystem helper shared with Composer internals.
+     */
     private readonly Filesystem $filesystem;
 
+    /**
+     * Absolute path to the root package vendor directory.
+     */
     private readonly string $vendorDir;
 
+    /**
+     * Absolute path where installer manifests are stored.
+     */
     private readonly string $manifestDir;
 
+    /**
+     * Absolute path to the root package directory.
+     */
     private readonly string $rootDir;
 
+    /**
+     * Creates a materializer bound to the active Composer root package.
+     */
     public function __construct(
         private readonly Composer $composer,
         private readonly IOInterface $io,
@@ -51,6 +96,14 @@ final class ResourceBundleMaterializer
         $this->manifestDir = $this->join($this->rootDir, 'vendor/fast-forward/.composer-installers');
     }
 
+    /**
+     * Copies the package payload into the configured consumer target path.
+     *
+     * @throws JsonException
+     * @throws RuntimeException When bundle metadata is invalid or files cannot be copied safely.
+     *
+     * @return void
+     */
     public function materialize(PackageInterface $package, string $installPath): void
     {
         $payloadPath = $this->payloadPath($package);
@@ -84,6 +137,13 @@ final class ResourceBundleMaterializer
         ), true, IOInterface::VERBOSE);
     }
 
+    /**
+     * Removes all paths tracked by the package manifest.
+     *
+     * @throws JsonException
+     *
+     * @return void
+     */
     public function remove(PackageInterface $package): void
     {
         $manifest = $this->readManifest($package);
@@ -104,6 +164,8 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Scans payload files and directories into manifest entries.
+     *
      * @return array<string, array{type: string, hash?: string}>
      */
     private function scanPayload(string $source): array
@@ -138,8 +200,14 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Copies all manifest entries from the source payload into the consumer target.
+     *
      * @param array<string, array{type: string, hash?: string}> $entries
      * @param array<string, array{type: string, hash?: string}> $previousEntries
+     *
+     * @throws RuntimeException When a consumer-owned path would be overwritten or a file copy fails.
+     *
+     * @return void
      */
     private function copyEntries(string $source, string $target, array $entries, array $previousEntries): void
     {
@@ -175,8 +243,12 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Removes entries that existed in the previous manifest but not in the next payload.
+     *
      * @param array<string, array{type: string, hash?: string}> $previousEntries
      * @param array<string, array{type: string, hash?: string}> $nextEntries
+     *
+     * @return void
      */
     private function removeStaleEntries(array $previousEntries, array $nextEntries, string $target): void
     {
@@ -185,7 +257,11 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Removes files and empty directories that belong to a manifest.
+     *
      * @param array<string, array{type: string, hash?: string}> $entries
+     *
+     * @return void
      */
     private function removeEntries(array $entries, string $target): void
     {
@@ -206,6 +282,11 @@ final class ResourceBundleMaterializer
         }
     }
 
+    /**
+     * Resolves the configured consumer target path for a resource bundle package.
+     *
+     * @throws RuntimeException When the root installer path metadata is invalid or missing.
+     */
     private function targetPath(PackageInterface $package): string
     {
         $rootExtra = $this->composer->getPackage()->getExtra();
@@ -233,6 +314,9 @@ final class ResourceBundleMaterializer
         ));
     }
 
+    /**
+     * Checks whether a root installer-paths match applies to a package.
+     */
     private function matchesPackage(string $match, PackageInterface $package): bool
     {
         return $match === $package->getName()
@@ -240,6 +324,11 @@ final class ResourceBundleMaterializer
             || $match === 'type:' . ResourceBundleInstaller::PACKAGE_TYPE;
     }
 
+    /**
+     * Resolves and validates the package payload directory metadata.
+     *
+     * @throws RuntimeException When the package does not declare a usable payload path.
+     */
     private function payloadPath(PackageInterface $package): string
     {
         $extra = $package->getExtra();
@@ -267,6 +356,10 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Reads the package manifest if one was written by a previous install or update.
+     *
+     * @throws JsonException
+     *
      * @return array{entries?: array<string, array{type: string, hash?: string}>, target-path?: string}
      */
     private function readManifest(PackageInterface $package): array
@@ -287,7 +380,13 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Writes the package manifest used by future updates and removals.
+     *
      * @param array<string, mixed> $manifest
+     *
+     * @throws JsonException
+     *
+     * @return void
      */
     private function writeManifest(PackageInterface $package, array $manifest): void
     {
@@ -304,6 +403,9 @@ final class ResourceBundleMaterializer
         );
     }
 
+    /**
+     * Resolves the manifest path for a package.
+     */
     private function manifestPath(PackageInterface $package): string
     {
         return $this->join(
@@ -312,6 +414,9 @@ final class ResourceBundleMaterializer
         );
     }
 
+    /**
+     * Replaces supported Composer installer path variables for a package.
+     */
     private function replaceVariables(string $path, PackageInterface $package): string
     {
         [$vendor, $name] = explode('/', $package->getPrettyName(), 2) + ['', $package->getPrettyName()];
@@ -323,6 +428,9 @@ final class ResourceBundleMaterializer
         ]);
     }
 
+    /**
+     * Resolves a path relative to the root package directory.
+     */
     private function absolutePath(string $path): string
     {
         if (str_starts_with($path, '/')) {
@@ -332,6 +440,9 @@ final class ResourceBundleMaterializer
         return rtrim($this->rootDir . '/' . $path, '/');
     }
 
+    /**
+     * Converts an absolute path into a root-package-relative path when possible.
+     */
     private function relativePath(string $path): string
     {
         $path = $this->normalizePath($path);
@@ -344,16 +455,25 @@ final class ResourceBundleMaterializer
         return $path;
     }
 
+    /**
+     * Joins two normalized path segments.
+     */
     private function join(string $left, string $right): string
     {
         return rtrim($left, '/') . '/' . ltrim($right, '/');
     }
 
+    /**
+     * Normalizes directory separators and outer slashes for manifest paths.
+     */
     private function normalizePath(string $path): string
     {
         return str_replace('\\', '/', trim($path, '/'));
     }
 
+    /**
+     * Creates the conflict exception used when a consumer-owned path would be overwritten.
+     */
     private function conflict(string $path): RuntimeException
     {
         return new RuntimeException(\sprintf(


### PR DESCRIPTION
## Summary
Adds the initial `fast-forward/composer-installers` Composer plugin for Fast Forward resource bundles.

## Changes
- Registers a Composer installer for `fast-forward-resource-bundle` packages.
- Reads package `extra.fast-forward-bundle.payload-path` and root `extra.installer-paths` mappings.
- Copies only payload contents into the consumer target directory as literal files, even when the source package is installed via a symlinked `path` repository.
- Tracks managed files in `vendor/fast-forward/.composer-installers/*.json` so package updates refresh copied files and remove stale managed files without taking ownership of unrelated consumer files.
- Documents the minimal bundle metadata and consumer configuration.

## Testing
- `composer validate --strict --no-check-lock`
- `find src -name '*.php' -print -exec php -l {} \;`
- `git diff --check`
- Local Composer smoke test with path repositories for this plugin and a fake `fast-forward/agents` package:
  - install copied `.agents/agents` and `.agents/skills` into the consumer without `.agents/agents/.agents`
  - materialized files were regular files, not symlinks
  - updating `fast-forward/agents` from `1.0.0` to `1.0.1` refreshed the copied file
  - stale managed payload file was removed
  - consumer-owned `.agents/local.md` was preserved

Closes #1
