### PR TITLE
Prepare 0.1.0 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-29
+
 ### Added
 
 - Bootstrap the `fast-forward/composer-installers` Composer plugin for Fast Forward resource bundles.
+
+
+[unreleased]: https://github.com/php-fast-forward/composer-installers/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/php-fast-forward/composer-installers/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Prepares the first `fast-forward/composer-installers` release by promoting the initial changelog entry into `0.1.0` dated `2026-04-29`.

## Changes

- Keeps an empty `Unreleased` section for future changes.
- Adds the published `0.1.0` changelog section.
- Adds compare/release links for `v0.1.0`.

## Testing

- `dev-tools changelog:show 0.1.0 --file=CHANGELOG.md`
- `composer validate --strict --no-check-lock`
- `git diff --check`

## Release

After merge, tag and publish GitHub release `v0.1.0` using the changelog notes.
