### PR TITLE
Support resource bundle install policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add resource bundle install policies for manifest recovery and authoritative payload refreshes.
+
 ## [0.1.0] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,18 +10,22 @@ are materialized into consumer-owned paths.
 ## Resource Package Metadata
 
 Resource packages use the `fast-forward-resource-bundle` type and declare the
-payload directory to copy:
+payload directory to copy. They may also declare how existing target files are
+handled when the manifest is missing:
 
 ```json
 {
   "type": "fast-forward-resource-bundle",
   "extra": {
     "fast-forward-bundle": {
-      "payload-path": ".agents"
+      "payload-path": ".agents",
+      "install-policy": "mutable"
     }
   }
 }
 ```
+
+`install-policy` is optional and defaults to `mutable`.
 
 ## Consumer Configuration
 
@@ -53,8 +57,22 @@ without creating `.agents/agents/.agents`.
 The installer writes a manifest under `vendor/fast-forward/.composer-installers`
 for each materialized package. On package update, files listed in the manifest
 are refreshed from the new payload and stale managed files are removed. Files
-that already exist in the target but are not tracked by the manifest are treated
-as consumer-owned and are not silently overwritten.
+that already exist in the target but are not tracked by the manifest are handled
+according to the bundle install policy.
+
+The `mutable` policy is the default. It adopts existing files when their content
+already matches the payload and recreates the manifest, which makes `composer
+install` safe after deleting `vendor/`. If an existing file differs from the
+payload and no manifest marks it as managed, installation fails instead of
+overwriting a consumer customization.
+
+The `authoritative` policy is intended for generated or shared automation such
+as GitHub workflow bundles. It overwrites existing divergent target files and
+then writes a fresh manifest, allowing committed workflow files to be refreshed
+after a clean clone where `vendor/` has not been installed yet. Authoritative
+bundles should use package-specific target directories or clearly owned file
+names, such as a `fast-forward-` prefix, so the installer only overwrites paths
+that are intentionally controlled by the bundle.
 
 The materialized payload is copied as literal files and directories. Composer
 `path` repositories may still symlink the package root in `vendor/`, but the

--- a/src/InstallPolicy.php
+++ b/src/InstallPolicy.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Composer installer plugin for Fast Forward resource bundles.
+ *
+ * This file is part of fast-forward/composer-installers project.
+ *
+ * @author   Felipe Sayao Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/composer-installers
+ * @see      https://github.com/php-fast-forward/composer-installers/issues
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\ComposerInstallers;
+
+/**
+ * Defines how resource bundles handle existing target files without a manifest.
+ */
+enum InstallPolicy: string
+{
+    /**
+     * Existing files are adopted only when their content matches the payload.
+     */
+    case Mutable = 'mutable';
+
+    /**
+     * Existing files are overwritten by the payload.
+     */
+    case Authoritative = 'authoritative';
+
+    /**
+     * Returns the default policy used by resource bundles.
+     */
+    public static function default(): self
+    {
+        return self::Mutable;
+    }
+
+    /**
+     * Checks whether this policy overwrites divergent existing files.
+     */
+    public function overwritesExistingFiles(): bool
+    {
+        return self::Authoritative === $this;
+    }
+}

--- a/src/ResourceBundleMaterializer.php
+++ b/src/ResourceBundleMaterializer.php
@@ -55,21 +55,6 @@ final class ResourceBundleMaterializer
     private const string INSTALL_POLICY_KEY = 'install-policy';
 
     /**
-     * Existing target files are adopted only when they match the payload.
-     */
-    private const string INSTALL_POLICY_MUTABLE = 'mutable';
-
-    /**
-     * Existing target files are overwritten by the payload.
-     */
-    private const string INSTALL_POLICY_AUTHORITATIVE = 'authoritative';
-
-    /**
-     * Default existing-file policy for resource bundles.
-     */
-    private const string DEFAULT_INSTALL_POLICY = self::INSTALL_POLICY_MUTABLE;
-
-    /**
      * Filesystem helper shared with Composer internals.
      */
     private readonly Filesystem $filesystem;
@@ -147,7 +132,7 @@ final class ResourceBundleMaterializer
         $this->writeManifest($package, [
             'package' => $package->getPrettyName(),
             'payload-path' => $payloadPath,
-            'install-policy' => $installPolicy,
+            'install-policy' => $installPolicy->value,
             'target-path' => $this->relativePath($target),
             'entries' => $nextEntries,
         ]);
@@ -236,7 +221,7 @@ final class ResourceBundleMaterializer
         string $target,
         array $entries,
         array $previousEntries,
-        string $installPolicy,
+        InstallPolicy $installPolicy,
     ): void {
         foreach ($entries as $relativePath => $entry) {
             $sourcePath = $this->join($source, $relativePath);
@@ -244,7 +229,7 @@ final class ResourceBundleMaterializer
 
             if ('dir' === $entry['type']) {
                 if (is_file($targetPath) || is_link($targetPath)) {
-                    if (self::INSTALL_POLICY_AUTHORITATIVE !== $installPolicy) {
+                    if (! $installPolicy->overwritesExistingFiles()) {
                         throw $this->conflict($targetPath, $installPolicy);
                     }
 
@@ -263,7 +248,7 @@ final class ResourceBundleMaterializer
                     continue;
                 }
 
-                if (self::INSTALL_POLICY_AUTHORITATIVE !== $installPolicy) {
+                if (! $installPolicy->overwritesExistingFiles()) {
                     throw $this->conflict($targetPath, $installPolicy);
                 }
             }
@@ -397,23 +382,24 @@ final class ResourceBundleMaterializer
      *
      * @throws RuntimeException When the package declares an unsupported install policy.
      */
-    private function installPolicy(PackageInterface $package): string
+    private function installPolicy(PackageInterface $package): InstallPolicy
     {
         $metadata = $this->bundleMetadata($package);
-        $installPolicy = (string) ($metadata[self::INSTALL_POLICY_KEY] ?? self::DEFAULT_INSTALL_POLICY);
+        $installPolicy = (string) ($metadata[self::INSTALL_POLICY_KEY] ?? InstallPolicy::default()->value);
+        $policy = InstallPolicy::tryFrom($installPolicy);
 
-        if (! \in_array($installPolicy, [self::INSTALL_POLICY_MUTABLE, self::INSTALL_POLICY_AUTHORITATIVE], true)) {
+        if (! $policy instanceof InstallPolicy) {
             throw new RuntimeException(\sprintf(
                 'Fast Forward resource bundle "%s" declares unsupported install policy "%s". '
                 . 'Supported policies: "%s", "%s".',
                 $package->getPrettyName(),
                 $installPolicy,
-                self::INSTALL_POLICY_MUTABLE,
-                self::INSTALL_POLICY_AUTHORITATIVE,
+                InstallPolicy::Mutable->value,
+                InstallPolicy::Authoritative->value,
             ));
         }
 
-        return $installPolicy;
+        return $policy;
     }
 
     /**
@@ -569,7 +555,7 @@ final class ResourceBundleMaterializer
     /**
      * Prepares a target path so a payload file can be copied into place.
      */
-    private function prepareFileTarget(string $targetPath, string $installPolicy): void
+    private function prepareFileTarget(string $targetPath, InstallPolicy $installPolicy): void
     {
         if (is_link($targetPath)) {
             unlink($targetPath);
@@ -581,7 +567,7 @@ final class ResourceBundleMaterializer
             return;
         }
 
-        if (self::INSTALL_POLICY_AUTHORITATIVE === $installPolicy && $this->filesystem->isDirEmpty($targetPath)) {
+        if ($installPolicy->overwritesExistingFiles() && $this->filesystem->isDirEmpty($targetPath)) {
             rmdir($targetPath);
 
             return;
@@ -593,13 +579,13 @@ final class ResourceBundleMaterializer
     /**
      * Creates the conflict exception used when a consumer-owned path would be overwritten.
      */
-    private function conflict(string $path, string $installPolicy): RuntimeException
+    private function conflict(string $path, InstallPolicy $installPolicy): RuntimeException
     {
         return new RuntimeException(\sprintf(
             'Refusing to overwrite consumer-owned path "%s" while using "%s" install policy. '
             . 'Remove it, restore the manifest, or use the "authoritative" policy for this bundle.',
             $this->relativePath($path),
-            $installPolicy,
+            $installPolicy->value,
         ));
     }
 }

--- a/src/ResourceBundleMaterializer.php
+++ b/src/ResourceBundleMaterializer.php
@@ -50,6 +50,26 @@ final class ResourceBundleMaterializer
     private const string PAYLOAD_PATH_KEY = 'payload-path';
 
     /**
+     * Resource package metadata key containing the existing-file policy.
+     */
+    private const string INSTALL_POLICY_KEY = 'install-policy';
+
+    /**
+     * Existing target files are adopted only when they match the payload.
+     */
+    private const string INSTALL_POLICY_MUTABLE = 'mutable';
+
+    /**
+     * Existing target files are overwritten by the payload.
+     */
+    private const string INSTALL_POLICY_AUTHORITATIVE = 'authoritative';
+
+    /**
+     * Default existing-file policy for resource bundles.
+     */
+    private const string DEFAULT_INSTALL_POLICY = self::INSTALL_POLICY_MUTABLE;
+
+    /**
      * Filesystem helper shared with Composer internals.
      */
     private readonly Filesystem $filesystem;
@@ -107,6 +127,7 @@ final class ResourceBundleMaterializer
     public function materialize(PackageInterface $package, string $installPath): void
     {
         $payloadPath = $this->payloadPath($package);
+        $installPolicy = $this->installPolicy($package);
         $source = $this->join($installPath, $payloadPath);
         $target = $this->targetPath($package);
 
@@ -122,10 +143,11 @@ final class ResourceBundleMaterializer
         $nextEntries = $this->scanPayload($source);
 
         $this->removeStaleEntries($previousManifest['entries'] ?? [], $nextEntries, $target);
-        $this->copyEntries($source, $target, $nextEntries, $previousManifest['entries'] ?? []);
+        $this->copyEntries($source, $target, $nextEntries, $previousManifest['entries'] ?? [], $installPolicy);
         $this->writeManifest($package, [
             'package' => $package->getPrettyName(),
             'payload-path' => $payloadPath,
+            'install-policy' => $installPolicy,
             'target-path' => $this->relativePath($target),
             'entries' => $nextEntries,
         ]);
@@ -209,15 +231,24 @@ final class ResourceBundleMaterializer
      *
      * @return void
      */
-    private function copyEntries(string $source, string $target, array $entries, array $previousEntries): void
-    {
+    private function copyEntries(
+        string $source,
+        string $target,
+        array $entries,
+        array $previousEntries,
+        string $installPolicy,
+    ): void {
         foreach ($entries as $relativePath => $entry) {
             $sourcePath = $this->join($source, $relativePath);
             $targetPath = $this->join($target, $relativePath);
 
             if ('dir' === $entry['type']) {
                 if (is_file($targetPath) || is_link($targetPath)) {
-                    throw $this->conflict($targetPath);
+                    if (self::INSTALL_POLICY_AUTHORITATIVE !== $installPolicy) {
+                        throw $this->conflict($targetPath, $installPolicy);
+                    }
+
+                    unlink($targetPath);
                 }
 
                 if (! is_dir($targetPath)) {
@@ -227,14 +258,22 @@ final class ResourceBundleMaterializer
                 continue;
             }
 
-            if (file_exists($targetPath) && ! isset($previousEntries[$relativePath])) {
-                throw $this->conflict($targetPath);
+            if ((file_exists($targetPath) || is_link($targetPath)) && ! isset($previousEntries[$relativePath])) {
+                if ($this->targetFileMatchesEntry($targetPath, $entry)) {
+                    continue;
+                }
+
+                if (self::INSTALL_POLICY_AUTHORITATIVE !== $installPolicy) {
+                    throw $this->conflict($targetPath, $installPolicy);
+                }
             }
 
             $parent = \dirname($targetPath);
             if (! is_dir($parent)) {
                 mkdir($parent, 0777, true);
             }
+
+            $this->prepareFileTarget($targetPath, $installPolicy);
 
             if (! copy($sourcePath, $targetPath)) {
                 throw new RuntimeException(\sprintf('Failed to copy "%s" to "%s".', $sourcePath, $targetPath));
@@ -331,10 +370,8 @@ final class ResourceBundleMaterializer
      */
     private function payloadPath(PackageInterface $package): string
     {
-        $extra = $package->getExtra();
-        $metadata = $extra[self::BUNDLE_EXTRA_KEY] ?? [];
-
-        if (! \is_array($metadata) || ! isset($metadata[self::PAYLOAD_PATH_KEY])) {
+        $metadata = $this->bundleMetadata($package);
+        if (! isset($metadata[self::PAYLOAD_PATH_KEY])) {
             throw new RuntimeException(\sprintf(
                 'Fast Forward resource bundle "%s" must declare extra.%s.%s.',
                 $package->getPrettyName(),
@@ -353,6 +390,51 @@ final class ResourceBundleMaterializer
         }
 
         return $payloadPath;
+    }
+
+    /**
+     * Resolves and validates the package install policy metadata.
+     *
+     * @throws RuntimeException When the package declares an unsupported install policy.
+     */
+    private function installPolicy(PackageInterface $package): string
+    {
+        $metadata = $this->bundleMetadata($package);
+        $installPolicy = (string) ($metadata[self::INSTALL_POLICY_KEY] ?? self::DEFAULT_INSTALL_POLICY);
+
+        if (! \in_array($installPolicy, [self::INSTALL_POLICY_MUTABLE, self::INSTALL_POLICY_AUTHORITATIVE], true)) {
+            throw new RuntimeException(\sprintf(
+                'Fast Forward resource bundle "%s" declares unsupported install policy "%s". '
+                . 'Supported policies: "%s", "%s".',
+                $package->getPrettyName(),
+                $installPolicy,
+                self::INSTALL_POLICY_MUTABLE,
+                self::INSTALL_POLICY_AUTHORITATIVE,
+            ));
+        }
+
+        return $installPolicy;
+    }
+
+    /**
+     * Resolves the package Fast Forward resource bundle metadata.
+     *
+     * @return array<string, mixed>
+     */
+    private function bundleMetadata(PackageInterface $package): array
+    {
+        $extra = $package->getExtra();
+        $metadata = $extra[self::BUNDLE_EXTRA_KEY] ?? [];
+
+        if (! \is_array($metadata)) {
+            throw new RuntimeException(\sprintf(
+                'Fast Forward resource bundle "%s" must declare extra.%s as an object.',
+                $package->getPrettyName(),
+                self::BUNDLE_EXTRA_KEY,
+            ));
+        }
+
+        return $metadata;
     }
 
     /**
@@ -472,13 +554,52 @@ final class ResourceBundleMaterializer
     }
 
     /**
+     * Checks whether a target file already matches a payload manifest entry.
+     *
+     * @param array{type: string, hash?: string} $entry
+     */
+    private function targetFileMatchesEntry(string $targetPath, array $entry): bool
+    {
+        return ! is_link($targetPath)
+            && is_file($targetPath)
+            && isset($entry['hash'])
+            && hash_file('sha256', $targetPath) === $entry['hash'];
+    }
+
+    /**
+     * Prepares a target path so a payload file can be copied into place.
+     */
+    private function prepareFileTarget(string $targetPath, string $installPolicy): void
+    {
+        if (is_link($targetPath)) {
+            unlink($targetPath);
+
+            return;
+        }
+
+        if (! is_dir($targetPath)) {
+            return;
+        }
+
+        if (self::INSTALL_POLICY_AUTHORITATIVE === $installPolicy && $this->filesystem->isDirEmpty($targetPath)) {
+            rmdir($targetPath);
+
+            return;
+        }
+
+        throw $this->conflict($targetPath, $installPolicy);
+    }
+
+    /**
      * Creates the conflict exception used when a consumer-owned path would be overwritten.
      */
-    private function conflict(string $path): RuntimeException
+    private function conflict(string $path, string $installPolicy): RuntimeException
     {
         return new RuntimeException(\sprintf(
-            'Refusing to overwrite consumer-owned path "%s". Remove it or let the installer manage it first.',
+            'Refusing to overwrite consumer-owned path "%s" while using "%s" install policy. '
+            . 'Remove it, restore the manifest, or use the "authoritative" policy for this bundle.',
             $this->relativePath($path),
+            $installPolicy,
         ));
     }
 }


### PR DESCRIPTION
## Summary

Adds per-bundle install policies so `fast-forward/composer-installers` can recover managed payload manifests after `vendor/` is deleted while still preserving repository-owned customizations by default.

## Changes

- Adds `extra.fast-forward-bundle.install-policy` metadata with `mutable` and `authoritative` policies.
- Represents supported policies with the `InstallPolicy` enum instead of loose string constants.
- Defaults omitted policy values to `mutable`.
- Recreates manifests when existing target files already match the payload.
- Keeps divergent existing files protected under `mutable` when no manifest marks them as managed.
- Allows `authoritative` bundles to overwrite divergent target files and recreate the manifest.
- Records the selected install policy in the manifest.
- Documents policy trade-offs, including using clearly owned names such as `fast-forward-` prefixes for authoritative bundles.
- Adds an Unreleased changelog entry.

## Testing

- `find src -name '*.php' -print -exec php -l {} \;`
- `composer validate --strict --no-check-lock`
- `git diff --check`
- `dev-tools changelog:check --file=CHANGELOG.md --against=origin/main`
- `agents/backup` smoke: deleted `vendor/` while keeping `.agents`; `composer install` adopted identical files and recreated the manifest with `install-policy: mutable`.
- `agents/backup` smoke: deleted `vendor/`, modified `.agents/agents/README.md`, and confirmed `mutable` fails with a consumer-owned path conflict.
- Temporary authoritative workflow bundle smoke: deleted `vendor/`, changed an existing committed workflow file, and confirmed `authoritative` overwrote it with the payload and recreated the manifest.
- Temporary invalid-policy smoke: confirmed unsupported policy metadata fails with a clear validation error.

Closes #4
