### PR TITLE
Prepare 0.2.0 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-29
+
 ### Added
 
 - Add resource bundle install policies for manifest recovery and authoritative payload refreshes.
@@ -18,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bootstrap the `fast-forward/composer-installers` Composer plugin for Fast Forward resource bundles.
 
 
-[unreleased]: https://github.com/php-fast-forward/composer-installers/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/php-fast-forward/composer-installers/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/php-fast-forward/composer-installers/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/php-fast-forward/composer-installers/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Prepares the `fast-forward/composer-installers` `0.2.0` release by promoting the install policy changelog entry into a released section dated `2026-04-29`.

## Changes

- Keeps an empty `Unreleased` section for future changes.
- Adds the published `0.2.0` changelog section.
- Updates changelog compare links for `v0.2.0`.

## Testing

- `dev-tools changelog:show 0.2.0 --file=CHANGELOG.md`
- `composer validate --strict --no-check-lock`
- `git diff --check`

## Release

After merge, tag and publish GitHub release `v0.2.0` with title `v0.2.0` using the changelog notes.
