### PR TITLE
[release] Prepare 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-29
+
 ### Changed
 
 - Skip consumer-owned path conflicts while continuing to materialize the rest of a resource bundle.
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bootstrap the `fast-forward/composer-installers` Composer plugin for Fast Forward resource bundles.
 
 
-[unreleased]: https://github.com/php-fast-forward/composer-installers/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/php-fast-forward/composer-installers/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/php-fast-forward/composer-installers/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/php-fast-forward/composer-installers/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/php-fast-forward/composer-installers/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Prepare the `0.3.0` changelog release section for the installer conflict handling update.

## Changes
- Promote the skip-and-continue installer behavior from `Unreleased` to `0.3.0` with the 2026-04-29 release date.
- Refresh changelog compare links for `v0.3.0`.

## Testing
- `composer validate --strict --no-check-lock`
- `git diff --check`
- `dev-tools changelog:show 0.3.0 --file=CHANGELOG.md`
